### PR TITLE
Changed Debian init script to use the root user instead of beaver

### DIFF
--- a/files/etc/init.d/beaver.Debian
+++ b/files/etc/init.d/beaver.Debian
@@ -13,7 +13,7 @@
 BEAVER_NAME='beaver'
 BEAVER_CMD='beaver -c /etc/beaver/beaver.conf'
 BEAVER_PID='/var/run/logstash_beaver.pid'
-BEAVER_USER='beaver'
+BEAVER_USER='root'
 BEAVER_LOG='/var/log/logstash_beaver.log'
 
 


### PR DESCRIPTION
This small change allows the script to actually start. In theory, this module would make the beaver user if it wanted to have a hard coded user.

Maybe pass a parameter.
