### PR TITLE
Fix debian/ubuntu deps

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -52,7 +52,7 @@ class beaver::params {
     'Debian', 'Ubuntu': {
       # main application
       $package = [ 'beaver' ]
-      $dep_packages = ['python-dev']
+      $dep_packages = ['python-dev', 'python-pip']
     }
     default: {
       fail("\"${module_name}\" provides no package default value

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -52,6 +52,7 @@ class beaver::params {
     'Debian', 'Ubuntu': {
       # main application
       $package = [ 'beaver' ]
+      $dep_packages = ['python-dev']
     }
     default: {
       fail("\"${module_name}\" provides no package default value


### PR DESCRIPTION
Add python-dev and python-pip as deps. since otherwise it tries to install 'undef'.
